### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -375,7 +375,7 @@ packages:
       name: golden_toolkit
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0"
+    version: "0.13.0"
   google_maps_webservice:
     dependency: "direct main"
     description:
@@ -389,7 +389,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   graphs:
     dependency: transitive
     description:
@@ -534,7 +534,7 @@ packages:
       name: loader_overlay
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4+3"
+    version: "2.0.5"
   logger:
     dependency: "direct main"
     description:
@@ -931,7 +931,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.2.11"
   supabase_flutter:
     dependency: "direct main"
     description:
@@ -945,7 +945,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.4+1"
   sync_http:
     dependency: transitive
     description:
@@ -1164,5 +1164,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0-178.1.beta <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -389,7 +389,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.2"
   graphs:
     dependency: transitive
     description:
@@ -931,7 +931,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.10"
   supabase_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   json_serializable: 6.1.3
   json_annotation: 4.4.0
   android_metadata: 0.2.1
-  loader_overlay: ^2.0.5
+  loader_overlay: 2.0.5
   package_info_plus: 1.3.0
   sentry_flutter: 6.2.2
   get: 4.6.1
@@ -71,9 +71,9 @@ dev_dependencies:
   mockito: 5.0.17
   network_image_mock: 2.0.1
   nock: 1.2.0
-  swagger_dart_code_generator: ^2.3.4+1
+  swagger_dart_code_generator: 2.3.4+1
   msix: 2.8.1
-  golden_toolkit: ^0.13.0
+  golden_toolkit: 0.13.0
   sentry_dart_plugin: 1.0.0-beta.1
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   json_serializable: 6.1.3
   json_annotation: 4.4.0
   android_metadata: 0.2.1
-  loader_overlay: 2.0.4+3
+  loader_overlay: ^2.0.5
   package_info_plus: 1.3.0
   sentry_flutter: 6.2.2
   get: 4.6.1
@@ -71,9 +71,9 @@ dev_dependencies:
   mockito: 5.0.17
   network_image_mock: 2.0.1
   nock: 1.2.0
-  swagger_dart_code_generator: 2.3.4
+  swagger_dart_code_generator: ^2.3.4+1
   msix: 2.8.1
-  golden_toolkit: 0.12.0
+  golden_toolkit: ^0.13.0
   sentry_dart_plugin: 1.0.0-beta.1
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/ChooseFood/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (32.0.0 available)
  analyzer 2.8.0 (3.0.0 available)
  android_metadata 0.2.1
  ansicolor 2.0.1
  archive 3.1.6 (3.1.8 available)
  args 2.3.0
  async 2.8.2
  back_button_interceptor 5.0.2
  boolean_selector 2.1.0
  build 2.2.1
  build_config 1.0.0
  build_daemon 3.0.1
  build_resolvers 2.0.6
  build_runner 2.1.7
  build_runner_core 7.2.3
  built_collection 5.1.1
  built_value 8.1.3
  characters 1.2.0
  charcode 1.3.1
  checked_yaml 2.0.1
  cli_util 0.3.5
  clock 1.1.0
  code_builder 4.1.0
  collection 1.15.0
  convert 3.0.1
  coverage 1.0.3 (1.0.4 available)
  crypto 3.0.1
  cupertino_icons 1.0.4
  dart_style 2.2.1
  equatable 2.0.3
  fake_async 1.2.0
  ffi 1.1.2
  file 6.1.2
  file_utils 1.0.1
  fixnum 1.0.0
  flutter 0.0.0 from sdk flutter
  flutter_contacts 1.1.2
  flutter_driver 0.0.0 from sdk flutter
  flutter_facebook_auth 4.0.0
  flutter_facebook_auth_platform_interface 3.0.1
  flutter_facebook_auth_web 3.0.0+1
  flutter_lints 1.0.4
  flutter_test 0.0.0 from sdk flutter
  flutter_web_plugins 0.0.0 from sdk flutter
  frontend_server_client 2.1.2
  fuchsia_remote_debug_protocol 0.0.0 from sdk flutter
  geolocator 8.0.1
  geolocator_android 3.0.1
  geolocator_apple 2.0.0+2
  geolocator_platform_interface 3.0.1
  geolocator_web 2.1.1
  get 4.6.1
  glob 2.0.2
  globbing 1.0.0
> golden_toolkit 0.13.0 (was 0.12.0)
  google_maps_webservice 0.0.20-nullsafety.5
> gotrue 0.1.3 (was 0.1.2)
  graphs 2.1.0
  hive 2.0.5
  hive_flutter 1.1.0
  http 0.13.4
  http_multi_server 3.0.1
  http_parser 4.0.0
  image 3.1.0
  injector 2.0.0
  integration_test 0.0.0 from sdk flutter
  intl_phone_number_input 0.7.0+2
  io 1.0.3
  js 0.6.3 (0.6.4 available)
  json_annotation 4.4.0
  json_serializable 6.1.3
  jwt_decode 0.3.1
  libphonenumber 2.0.2
  libphonenumber_platform_interface 0.3.1
  libphonenumber_plugin 0.2.3
  libphonenumber_web 0.2.0+1
  lints 1.0.1
> loader_overlay 2.0.5 (was 2.0.4+3)
  logger 1.1.0
  logging 1.0.2
  markdown 4.0.1
  matcher 0.12.11
  material_color_utilities 0.1.2 (0.1.3 available)
  meta 1.7.0
  mime 1.0.1
  mockito 5.0.17
  msix 2.8.1
  network_image_mock 2.0.1
  nock 1.2.0
  node_preamble 2.0.1
  package_config 2.0.2
  package_info_plus 1.3.0
  package_info_plus_linux 1.0.3
  package_info_plus_macos 1.3.0
  package_info_plus_platform_interface 1.0.2
  package_info_plus_web 1.0.4
  package_info_plus_windows 1.0.4
  path 1.8.0 (1.8.1 available)
  path_provider 2.0.8
  path_provider_android 2.0.11
  path_provider_ios 2.0.7
  path_provider_linux 2.1.5
  path_provider_macos 2.0.5
  path_provider_platform_interface 2.0.3
  path_provider_windows 2.0.5
  petitparser 4.4.0
  platform 3.1.0
  plugin_platform_interface 2.1.2
  pool 1.5.0
  postgrest 0.1.9
  process 4.2.4
  pub_semver 2.1.0
  pubspec_parse 1.2.0
  realtime_client 0.1.13
  recase 4.0.0
  sentry 6.2.2
  sentry_dart_plugin 1.0.0-beta.1
  sentry_flutter 6.2.2
  sentry_logging 6.2.2
  shelf 1.2.0
  shelf_packages_handler 3.0.0
  shelf_static 1.1.0
  shelf_web_socket 1.0.1
  sky_engine 0.0.99 from sdk flutter
  source_gen 1.2.1
  source_helper 1.3.1
  source_map_stack_trace 2.1.0
  source_maps 0.10.10
  source_span 1.8.1
  stack_trace 1.10.0
  storage_client 0.0.6+2
  stream_channel 2.1.0
  stream_transform 2.0.0
  string_scanner 1.1.0
> supabase 0.2.11 (was 0.2.10)
  supabase_flutter 0.2.9
> swagger_dart_code_generator 2.3.4+1 (was 2.3.4)
  sync_http 0.3.0
  system_info 1.0.1
  term_glyph 1.2.0
  test 1.19.5 (1.20.1 available)
  test_api 0.4.8 (0.4.9 available)
  test_core 0.4.9 (0.4.11 available)
  timing 1.0.0
  typed_data 1.3.0
  uni_links 0.5.1
  uni_links_platform_interface 1.0.0
  uni_links_web 0.1.0
  universal_io 2.0.4
  url_launcher 6.0.18
  url_launcher_android 6.0.14
  url_launcher_ios 6.0.14
  url_launcher_linux 2.0.2
  url_launcher_macos 2.0.2
  url_launcher_platform_interface 2.0.5
  url_launcher_web 2.0.6
  url_launcher_windows 2.0.2
  uuid 3.0.5
  vector_math 2.1.1
  vm_service 7.5.0 (8.1.0 available)
  watcher 1.0.1
  web_socket_channel 2.1.0
  webdriver 3.0.0
  webkit_inspection_protocol 1.0.0
  win32 2.3.3
  xdg_directories 0.2.0
  xml 5.3.1
  yaml 3.1.0
Downloading golden_toolkit 0.13.0...
Downloading swagger_dart_code_generator 2.3.4+1...
Downloading loader_overlay 2.0.5...
Downloading supabase 0.2.11...
Downloading gotrue 0.1.3...
Changed 5 dependencies!
11 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

Changed 3 constraints in pubspec.yaml:
  loader_overlay: 2.0.4+3 -> ^2.0.5
  swagger_dart_code_generator: 2.3.4 -> ^2.3.4+1
  golden_toolkit: 0.12.0 -> ^0.13.0
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- pubspec.lock
- pubspec.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)