### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1050,28 +1050,28 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.15"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.15"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1092,7 +1092,7 @@ packages:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -966,7 +966,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -966,7 +966,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -604,7 +604,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.15"
+    version: "2.8.17"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -1148,7 +1148,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.10"
+    version: "2.3.11"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1141,7 +1141,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  cli_dialog:
+    dependency: transitive
+    description:
+      name: cli_dialog
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   cli_util:
     dependency: transitive
     description:
@@ -197,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  dart_console:
+    dependency: transitive
+    description:
+      name: dart_console
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -604,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.18"
+    version: "3.0.0"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -786,7 +786,7 @@ packages:
       name: realtime_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.13"
+    version: "0.1.14"
   recase:
     dependency: transitive
     description:
@@ -931,14 +931,14 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.12"
+    version: "0.2.13"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.2.11"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -952,7 +952,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.14"
+    version: "0.2.15"
   supabase_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -271,7 +271,7 @@ packages:
       name: flutter_contacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.2.0"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,7 +319,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.3"
+    version: "8.0.4"
   geolocator_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,7 +319,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.5"
+    version: "8.1.0"
   geolocator_android:
     dependency: transitive
     description:
@@ -348,6 +348,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   get:
     dependency: "direct main"
     description:
@@ -597,7 +604,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.8"
+    version: "2.8.13"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -800,7 +807,7 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
@@ -814,14 +821,14 @@ packages:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   sentry_logging:
     dependency: "direct main"
     description:
       name: sentry_logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   shelf:
     dependency: transitive
     description:
@@ -1148,7 +1155,7 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   xml:
     dependency: transitive
     description:
@@ -1165,4 +1172,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.15.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.8.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -410,7 +410,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.6"
   graphs:
     dependency: transitive
     description:
@@ -555,7 +555,7 @@ packages:
       name: loader_overlay
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.5+1"
   logger:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -1113,7 +1113,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,35 +319,35 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.1"
+    version: "8.0.3"
   geolocator_android:
     dependency: transitive
     description:
       name: geolocator_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   geolocator_apple:
     dependency: transitive
     description:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+2"
+    version: "2.0.1"
   geolocator_platform_interface:
     dependency: transitive
     description:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.1"
   geolocator_web:
     dependency: transitive
     description:
       name: geolocator_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   get:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.6"
+    version: "2.8.7"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -1141,7 +1141,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
+    version: "2.3.10"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -431,7 +431,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -604,7 +604,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.17"
+    version: "2.8.18"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -688,7 +688,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   path_provider_android:
     dependency: transitive
     description:
@@ -1043,7 +1043,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.18"
+    version: "6.0.20"
   url_launcher_android:
     dependency: transitive
     description:
@@ -1064,14 +1064,14 @@ packages:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1092,7 +1092,7 @@ packages:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.0"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -389,7 +389,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   graphs:
     dependency: transitive
     description:
@@ -931,7 +931,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.2.11"
   supabase_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   characters:
     dependency: transitive
     description:
@@ -938,14 +938,14 @@ packages:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9"
+    version: "0.2.10"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.5"
+    version: "2.3.8"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.7"
+    version: "2.8.8"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.3"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -945,7 +945,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.9"
+    version: "2.3.10"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1064,7 +1064,7 @@ packages:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1141,7 +1141,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.8"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -389,7 +389,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   graphs:
     dependency: transitive
     description:
@@ -786,7 +786,7 @@ packages:
       name: realtime_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.14"
+    version: "0.1.15"
   recase:
     dependency: transitive
     description:
@@ -931,14 +931,14 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.13"
+    version: "0.2.14"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.12"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1162,7 +1162,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1141,7 +1141,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.5"
+    version: "2.8.6"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -945,7 +945,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.10"
+    version: "2.3.13"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -597,7 +597,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.3"
+    version: "2.8.5"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -424,7 +424,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   hive_flutter:
     dependency: transitive
     description:
@@ -709,7 +709,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   path_provider_ios:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,7 +319,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.4"
+    version: "8.0.5"
   geolocator_android:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -604,7 +604,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.13"
+    version: "2.8.15"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,7 +269,7 @@ packages:
       name: flutter_facebook_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   flutter_facebook_auth_platform_interface:
     dependency: transitive
     description:
@@ -438,7 +438,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   injector:
     dependency: transitive
     description:
@@ -485,7 +485,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.4"
   jwt_decode:
     dependency: "direct main"
     description:
@@ -931,7 +931,7 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.12"
   supabase_flutter:
     dependency: "direct main"
     description:
@@ -945,7 +945,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4+1"
+    version: "2.3.5"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -340,14 +340,14 @@ packages:
       name: geolocator_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   geolocator_apple:
     dependency: transitive
     description:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   geolocator_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -506,7 +506,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   jwt_decode:
     dependency: "direct main"
     description:
@@ -793,7 +793,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1057,7 +1057,7 @@ packages:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_macos:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -945,7 +945,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.8"
+    version: "2.3.9"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -319,7 +319,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.1"
   geolocator_android:
     dependency: transitive
     description:
@@ -340,7 +340,7 @@ packages:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   geolocator_web:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -333,14 +333,14 @@ packages:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   geolocator_platform_interface:
     dependency: transitive
     description:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   geolocator_web:
     dependency: transitive
     description:
@@ -597,7 +597,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.17"
+    version: "5.1.0"
   msix:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.1"
+    version: "8.2.0"
   geolocator_android:
     dependency: transitive
     description:
@@ -347,7 +347,7 @@ packages:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.1+1"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -1162,7 +1162,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.11"
+    version: "2.4.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1141,7 +1141,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.8"
+    version: "2.3.9"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -459,7 +459,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   injector:
     dependency: transitive
     description:
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   network_image_mock:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,7 +283,7 @@ packages:
       name: flutter_facebook_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.1.1"
   flutter_facebook_auth_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -716,7 +716,7 @@ packages:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -653,7 +653,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   package_info_plus_linux:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -618,7 +618,7 @@ packages:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -653,7 +653,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -966,7 +966,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.13"
+    version: "2.4.1"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,13 +44,13 @@ dependencies:
   android_metadata: 0.2.1
   loader_overlay: 2.0.5
   package_info_plus: 1.3.0
-  sentry_flutter: 6.2.2
+  sentry_flutter: ^6.3.0
   get: 4.6.1
   supabase_flutter: ^0.2.10
   intl_phone_number_input: 0.7.0+2
   flutter_contacts: 1.1.2
   jwt_decode: 0.3.1
-  sentry_logging: 6.2.2
+  sentry_logging: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   json_annotation: 4.4.0
   android_metadata: 0.2.1
   loader_overlay: 2.0.5
-  package_info_plus: 1.3.0
+  package_info_plus: ^1.3.1
   sentry_flutter: ^6.3.0
   get: 4.6.1
   supabase_flutter: ^0.2.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   flutter_facebook_auth: 4.0.0
   logger: 1.1.0
   google_maps_webservice: 0.0.20-nullsafety.5
-  geolocator: 8.0.1
+  geolocator: ^8.0.3
   json_serializable: 6.1.3
   json_annotation: 4.4.0
   android_metadata: 0.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dev_dependencies:
   flutter_lints: 1.0.4
   test: 1.19.5
   build_runner: 2.1.7
-  mockito: 5.0.17
+  mockito: ^5.1.0
   network_image_mock: 2.0.1
   nock: 1.2.0
   swagger_dart_code_generator: ^2.3.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dev_dependencies:
   network_image_mock: 2.0.1
   nock: 1.2.0
   swagger_dart_code_generator: ^2.3.5
-  msix: ^2.8.2
+  msix: ^3.0.0
   golden_toolkit: 0.13.0
   sentry_dart_plugin: 1.0.0-beta.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   json_serializable: ^6.1.4
   json_annotation: 4.4.0
   android_metadata: 0.2.1
-  loader_overlay: 2.0.5
+  loader_overlay: ^2.0.5+1
   package_info_plus: ^1.3.1
   sentry_flutter: ^6.3.0
   get: 4.6.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dev_dependencies:
   network_image_mock: 2.0.1
   nock: 1.2.0
   swagger_dart_code_generator: ^2.3.5
-  msix: 2.8.1
+  msix: ^2.8.2
   golden_toolkit: 0.13.0
   sentry_dart_plugin: 1.0.0-beta.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   get: 4.6.1
   supabase_flutter: ^0.2.10
   intl_phone_number_input: 0.7.0+2
-  flutter_contacts: 1.1.2
+  flutter_contacts: ^1.1.3
   jwt_decode: 0.3.1
   sentry_logging: ^6.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   package_info_plus: 1.3.0
   sentry_flutter: 6.2.2
   get: 4.6.1
-  supabase_flutter: 0.2.9
+  supabase_flutter: ^0.2.10
   intl_phone_number_input: 0.7.0+2
   flutter_contacts: 1.1.2
   jwt_decode: 0.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,11 +35,11 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
-  flutter_facebook_auth: 4.0.0
+  flutter_facebook_auth: ^4.0.1
   logger: 1.1.0
   google_maps_webservice: 0.0.20-nullsafety.5
   geolocator: ^8.0.3
-  json_serializable: 6.1.3
+  json_serializable: ^6.1.4
   json_annotation: 4.4.0
   android_metadata: 0.2.1
   loader_overlay: 2.0.5
@@ -71,7 +71,7 @@ dev_dependencies:
   mockito: 5.0.17
   network_image_mock: 2.0.1
   nock: 1.2.0
-  swagger_dart_code_generator: 2.3.4+1
+  swagger_dart_code_generator: ^2.3.5
   msix: 2.8.1
   golden_toolkit: 0.13.0
   sentry_dart_plugin: 1.0.0-beta.1


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/ChooseFood/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (32.0.0 available)
  analyzer 2.8.0 (3.0.0 available)
  android_metadata 0.2.1
  ansicolor 2.0.1
  archive 3.1.6 (3.1.8 available)
  args 2.3.0
  async 2.8.2
  back_button_interceptor 5.0.2
  boolean_selector 2.1.0
  build 2.2.1
  build_config 1.0.0
  build_daemon 3.0.1
  build_resolvers 2.0.6
  build_runner 2.1.7
  build_runner_core 7.2.3
  built_collection 5.1.1
  built_value 8.1.3
  characters 1.2.0
  charcode 1.3.1
  checked_yaml 2.0.1
  cli_util 0.3.5
  clock 1.1.0
  code_builder 4.1.0
  collection 1.15.0
  convert 3.0.1
  coverage 1.0.3 (1.0.4 available)
  crypto 3.0.1
  cupertino_icons 1.0.4
  dart_style 2.2.1
  equatable 2.0.3
  fake_async 1.2.0
  ffi 1.1.2
  file 6.1.2
  file_utils 1.0.1
  fixnum 1.0.0
  flutter 0.0.0 from sdk flutter
  flutter_contacts 1.1.2
  flutter_driver 0.0.0 from sdk flutter
  flutter_facebook_auth 4.0.0
  flutter_facebook_auth_platform_interface 3.0.1
  flutter_facebook_auth_web 3.0.0+1
  flutter_lints 1.0.4
  flutter_test 0.0.0 from sdk flutter
  flutter_web_plugins 0.0.0 from sdk flutter
  frontend_server_client 2.1.2
  fuchsia_remote_debug_protocol 0.0.0 from sdk flutter
  geolocator 8.0.1
  geolocator_android 3.0.1
  geolocator_apple 2.0.0+2
  geolocator_platform_interface 3.0.1
  geolocator_web 2.1.1
  get 4.6.1
  glob 2.0.2
  globbing 1.0.0
  golden_toolkit 0.13.0
  google_maps_webservice 0.0.20-nullsafety.5
> gotrue 0.1.3 (was 0.1.2)
  graphs 2.1.0
  hive 2.0.5
  hive_flutter 1.1.0
  http 0.13.4
  http_multi_server 3.0.1
  http_parser 4.0.0
  image 3.1.0
  injector 2.0.0
  integration_test 0.0.0 from sdk flutter
  intl_phone_number_input 0.7.0+2
  io 1.0.3
  js 0.6.3 (0.6.4 available)
  json_annotation 4.4.0
  json_serializable 6.1.3
  jwt_decode 0.3.1
  libphonenumber 2.0.2
  libphonenumber_platform_interface 0.3.1
  libphonenumber_plugin 0.2.3
  libphonenumber_web 0.2.0+1
  lints 1.0.1
  loader_overlay 2.0.5
  logger 1.1.0
  logging 1.0.2
  markdown 4.0.1
  matcher 0.12.11
  material_color_utilities 0.1.2 (0.1.3 available)
  meta 1.7.0
  mime 1.0.1
  mockito 5.0.17
  msix 2.8.1
  network_image_mock 2.0.1
  nock 1.2.0
  node_preamble 2.0.1
  package_config 2.0.2
  package_info_plus 1.3.0
  package_info_plus_linux 1.0.3
  package_info_plus_macos 1.3.0
  package_info_plus_platform_interface 1.0.2
  package_info_plus_web 1.0.4
  package_info_plus_windows 1.0.4
  path 1.8.0 (1.8.1 available)
  path_provider 2.0.8
  path_provider_android 2.0.11
  path_provider_ios 2.0.7
  path_provider_linux 2.1.5
  path_provider_macos 2.0.5
  path_provider_platform_interface 2.0.3
  path_provider_windows 2.0.5
  petitparser 4.4.0
  platform 3.1.0
  plugin_platform_interface 2.1.2
  pool 1.5.0
  postgrest 0.1.9
  process 4.2.4
  pub_semver 2.1.0
  pubspec_parse 1.2.0
  realtime_client 0.1.13
  recase 4.0.0
  sentry 6.2.2
  sentry_dart_plugin 1.0.0-beta.1
  sentry_flutter 6.2.2
  sentry_logging 6.2.2
  shelf 1.2.0
  shelf_packages_handler 3.0.0
  shelf_static 1.1.0
  shelf_web_socket 1.0.1
  sky_engine 0.0.99 from sdk flutter
  source_gen 1.2.1
  source_helper 1.3.1
  source_map_stack_trace 2.1.0
  source_maps 0.10.10
  source_span 1.8.1
  stack_trace 1.10.0
  storage_client 0.0.6+2
  stream_channel 2.1.0
  stream_transform 2.0.0
  string_scanner 1.1.0
> supabase 0.2.11 (was 0.2.10)
  supabase_flutter 0.2.9
  swagger_dart_code_generator 2.3.4+1
  sync_http 0.3.0
  system_info 1.0.1
  term_glyph 1.2.0
  test 1.19.5 (1.20.1 available)
  test_api 0.4.8 (0.4.9 available)
  test_core 0.4.9 (0.4.11 available)
  timing 1.0.0
  typed_data 1.3.0
  uni_links 0.5.1
  uni_links_platform_interface 1.0.0
  uni_links_web 0.1.0
  universal_io 2.0.4
  url_launcher 6.0.18
  url_launcher_android 6.0.14
  url_launcher_ios 6.0.14
  url_launcher_linux 2.0.2
  url_launcher_macos 2.0.2
  url_launcher_platform_interface 2.0.5
  url_launcher_web 2.0.6
  url_launcher_windows 2.0.2
  uuid 3.0.5
  vector_math 2.1.1
  vm_service 7.5.0 (8.1.0 available)
  watcher 1.0.1
  web_socket_channel 2.1.0
  webdriver 3.0.0
  webkit_inspection_protocol 1.0.0
  win32 2.3.3
  xdg_directories 0.2.0
  xml 5.3.1
  yaml 3.1.0
Downloading supabase 0.2.11...
Downloading gotrue 0.1.3...
Changed 2 dependencies!
11 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

No changes to pubspec.yaml!
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- pubspec.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)