### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.10"
   build_runner_core:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.3"
+    version: "8.3.0"
   characters:
     dependency: transitive
     description:
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  cli_dialog:
+    dependency: transitive
+    description:
+      name: cli_dialog
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   cli_util:
     dependency: transitive
     description:
@@ -197,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  dart_console:
+    dependency: transitive
+    description:
+      name: dart_console
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -224,7 +238,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -245,7 +259,7 @@ packages:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -257,7 +271,7 @@ packages:
       name: flutter_contacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.4"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -269,21 +283,21 @@ packages:
       name: flutter_facebook_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.3.4"
   flutter_facebook_auth_platform_interface:
     dependency: transitive
     description:
       name: flutter_facebook_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   flutter_facebook_auth_web:
     dependency: transitive
     description:
       name: flutter_facebook_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0+1"
+    version: "3.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -319,35 +333,42 @@ packages:
       name: geolocator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.1"
+    version: "8.2.1"
   geolocator_android:
     dependency: transitive
     description:
       name: geolocator_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.8"
   geolocator_apple:
     dependency: transitive
     description:
       name: geolocator_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+2"
+    version: "2.1.3"
   geolocator_platform_interface:
     dependency: transitive
     description:
       name: geolocator_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.5"
   geolocator_web:
     dependency: transitive
     description:
       name: geolocator_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.5"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   get:
     dependency: "direct main"
     description:
@@ -355,6 +376,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.6.1"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   glob:
     dependency: transitive
     description:
@@ -389,7 +417,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.2"
   graphs:
     dependency: transitive
     description:
@@ -403,7 +431,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   hive_flutter:
     dependency: transitive
     description:
@@ -424,7 +452,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -438,7 +466,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
   injector:
     dependency: transitive
     description:
@@ -478,14 +506,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.5.0"
   json_serializable:
     dependency: "direct main"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.2.0"
   jwt_decode:
     dependency: "direct main"
     description:
@@ -534,7 +562,7 @@ packages:
       name: loader_overlay
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   logger:
     dependency: "direct main"
     description:
@@ -555,7 +583,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -563,15 +591,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_you_colours:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: bf92cd1
-      resolved-ref: 9bec0cb305124ef7f4e350627f01bf1e6cd6396f
-      url: "https://github.com/Mause/material_you_colours"
-    source: git
-    version: "0.0.1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -579,6 +598,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  material_you_colours:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: "9bec0cb3"
+      resolved-ref: "9bec0cb305124ef7f4e350627f01bf1e6cd6396f"
+      url: "https://github.com/Mause/material_you_colours"
+    source: git
+    version: "0.0.1"
   meta:
     dependency: transitive
     description:
@@ -592,28 +620,28 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.17"
+    version: "5.1.0"
   msix:
     dependency: "direct dev"
     description:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "3.6.2"
   network_image_mock:
     dependency: "direct dev"
     description:
       name: network_image_mock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   nock:
     dependency: "direct dev"
     description:
@@ -641,14 +669,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.2"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_info_plus_macos:
     dependency: transitive
     description:
@@ -669,14 +697,14 @@ packages:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -690,49 +718,49 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.10"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.14"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.9"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   petitparser:
     dependency: transitive
     description:
@@ -767,7 +795,7 @@ packages:
       name: postgrest
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.9"
+    version: "0.1.10+1"
   process:
     dependency: transitive
     description:
@@ -781,7 +809,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
@@ -795,7 +823,7 @@ packages:
       name: realtime_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.13"
+    version: "0.1.15"
   recase:
     dependency: transitive
     description:
@@ -809,28 +837,28 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.5.1"
   sentry_dart_plugin:
     dependency: "direct dev"
     description:
       name: sentry_dart_plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-beta.1"
+    version: "1.0.0-beta.2"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.5.1"
   sentry_logging:
     dependency: "direct main"
     description:
       name: sentry_logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.5.1"
   shelf:
     dependency: transitive
     description:
@@ -870,14 +898,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -940,21 +968,21 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.3.0"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9"
+    version: "0.3.0"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4+1"
+    version: "2.5.1+1"
   sync_http:
     dependency: transitive
     description:
@@ -962,13 +990,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
-  system_info:
+  system_info2:
     dependency: transitive
     description:
-      name: system_info
+      name: system_info2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.3"
   term_glyph:
     dependency: transitive
     description:
@@ -1045,35 +1073,35 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.18"
+    version: "6.1.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.17"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.16"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1094,14 +1122,14 @@ packages:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.1"
   uuid:
     dependency: transitive
     description:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:
@@ -1129,7 +1157,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   webdriver:
     dependency: transitive
     description:
@@ -1143,21 +1171,21 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.5.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   xml:
     dependency: transitive
     description:
@@ -1171,7 +1199,7 @@ packages:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
   dart: ">=2.15.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.8.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -982,7 +982,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.1+1"
+    version: "2.5.2"
   sync_http:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,22 +35,22 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
-  flutter_facebook_auth: 4.0.0
+  flutter_facebook_auth: ^4.3.4
   logger: 1.1.0
   google_maps_webservice: 0.0.20-nullsafety.5
-  geolocator: 8.0.1
-  json_serializable: 6.1.3
-  json_annotation: 4.4.0
+  geolocator: ^8.2.1
+  json_serializable: ^6.2.0
+  json_annotation: ^4.5.0
   android_metadata: 0.2.1
-  loader_overlay: 2.0.5
-  package_info_plus: 1.3.0
-  sentry_flutter: 6.2.2
+  loader_overlay: ^2.0.6
+  package_info_plus: ^1.4.2
+  sentry_flutter: ^6.5.1
   get: 4.6.1
-  supabase_flutter: 0.2.9
+  supabase_flutter: ^0.3.0
   intl_phone_number_input: 0.7.0+2
-  flutter_contacts: 1.1.2
+  flutter_contacts: ^1.1.4
   jwt_decode: 0.3.1
-  sentry_logging: 6.2.2
+  sentry_logging: ^6.5.1
   material_you_colours:
     git:
       url: https://github.com/Mause/material_you_colours
@@ -72,13 +72,13 @@ dev_dependencies:
   flutter_lints: 1.0.4
   test: ^1.19.5
   build_runner: 2.1.10
-  mockito: 5.0.17
-  network_image_mock: 2.0.1
+  mockito: ^5.1.0
+  network_image_mock: ^2.1.0
   nock: 1.2.0
-  swagger_dart_code_generator: 2.3.4+1
-  msix: 2.8.1
+  swagger_dart_code_generator: ^2.5.1+1
+  msix: ^3.6.2
   golden_toolkit: 0.13.0
-  sentry_dart_plugin: 1.0.0-beta.1
+  sentry_dart_plugin: ^1.0.0-beta.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/ChooseFood/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (39.0.0 available)
  analyzer 2.8.0 (4.0.0 available)
  android_metadata 0.2.1
  ansicolor 2.0.1
  archive 3.1.6 (3.3.0 available)
> args 2.3.1 (was 2.3.0)
  async 2.8.2 (2.9.0 available)
  back_button_interceptor 5.0.2 (6.0.0 available)
  boolean_selector 2.1.0
> build 2.3.0 (was 2.2.1)
  build_config 1.0.0
> build_daemon 3.1.0 (was 3.0.1)
  build_resolvers 2.0.6 (2.0.8 available)
> build_runner 2.1.10 (was 2.1.7)
  build_runner_core 7.2.3
  built_collection 5.1.1
> built_value 8.3.0 (was 8.1.3)
  characters 1.2.0 (1.2.1 available)
  charcode 1.3.1
  checked_yaml 2.0.1
+ cli_dialog 0.5.0
  cli_util 0.3.5
  clock 1.1.0
  code_builder 4.1.0
  collection 1.15.0 (1.16.0 available)
  convert 3.0.1
  coverage 1.0.3 (1.3.1 available)
  crypto 3.0.1 (3.0.2 available)
  cupertino_icons 1.0.4
+ dart_console 1.0.0
  dart_style 2.2.1 (2.2.3 available)
  equatable 2.0.3
  fake_async 1.2.0 (1.3.0 available)
> ffi 1.2.1 (was 1.1.2)
  file 6.1.2
  file_utils 1.0.1
> fixnum 1.0.1 (was 1.0.0)
  flutter 0.0.0 from sdk flutter
> flutter_contacts 1.1.4 (was 1.1.2)
  flutter_driver 0.0.0 from sdk flutter
> flutter_facebook_auth 4.3.4 (was 4.0.0)
> flutter_facebook_auth_platform_interface 3.1.2 (was 3.0.1) (4.0.0 available)
> flutter_facebook_auth_web 3.1.2 (was 3.0.0+1) (4.0.0 available)
  flutter_lints 1.0.4 (2.0.1 available)
  flutter_test 0.0.0 from sdk flutter
  flutter_web_plugins 0.0.0 from sdk flutter
  frontend_server_client 2.1.2
  fuchsia_remote_debug_protocol 0.0.0 from sdk flutter
> geolocator 8.2.1 (was 8.0.1)
> geolocator_android 3.1.8 (was 3.0.1)
> geolocator_apple 2.1.3 (was 2.0.0+2)
> geolocator_platform_interface 4.0.5 (was 3.0.1)
> geolocator_web 2.1.5 (was 2.1.1)
+ geolocator_windows 0.1.1
  get 4.6.1 (4.6.3 available)
+ get_it 7.2.0
  glob 2.0.2
  globbing 1.0.0
  golden_toolkit 0.13.0
  google_maps_webservice 0.0.20-nullsafety.5
> gotrue 0.2.2 (was 0.1.2)
  graphs 2.1.0
> hive 2.1.0 (was 2.0.5)
  hive_flutter 1.1.0
  http 0.13.4
> http_multi_server 3.2.0 (was 3.0.1)
  http_parser 4.0.0
> image 3.1.3 (was 3.1.0)
  injector 2.0.0
  integration_test 0.0.0 from sdk flutter
  intl_phone_number_input 0.7.0+2
  io 1.0.3
  js 0.6.3 (0.6.4 available)
> json_annotation 4.5.0 (was 4.4.0)
> json_serializable 6.2.0 (was 6.1.3)
  jwt_decode 0.3.1
  libphonenumber 2.0.2
  libphonenumber_platform_interface 0.3.1
  libphonenumber_plugin 0.2.3
  libphonenumber_web 0.2.0+1
  lints 1.0.1 (2.0.0 available)
> loader_overlay 2.0.6 (was 2.0.5)
  logger 1.1.0
  logging 1.0.2
> markdown 5.0.0 (was 4.0.1)
  matcher 0.12.11
  material_color_utilities 0.1.2 (0.1.5 available)
* material_you_colours 0.0.1 from git https://github.com/Mause/material_you_colours at 9bec0c (was 0.0.1 from git https://github.com/Mause/material_you_colours at 9bec0c)
  meta 1.7.0
> mime 1.0.2 (was 1.0.1)
> mockito 5.1.0 (was 5.0.17)
> msix 3.6.2 (was 2.8.1)
> network_image_mock 2.1.0 (was 2.0.1)
  nock 1.2.0
  node_preamble 2.0.1
  package_config 2.0.2
> package_info_plus 1.4.2 (was 1.3.0)
> package_info_plus_linux 1.0.5 (was 1.0.3)
  package_info_plus_macos 1.3.0
  package_info_plus_platform_interface 1.0.2
> package_info_plus_web 1.0.5 (was 1.0.4)
> package_info_plus_windows 1.0.5 (was 1.0.4)
  path 1.8.0 (1.8.1 available)
> path_provider 2.0.10 (was 2.0.8)
> path_provider_android 2.0.14 (was 2.0.11)
> path_provider_ios 2.0.9 (was 2.0.7)
> path_provider_linux 2.1.6 (was 2.1.5)
> path_provider_macos 2.0.6 (was 2.0.5)
> path_provider_platform_interface 2.0.4 (was 2.0.3)
> path_provider_windows 2.0.6 (was 2.0.5)
  petitparser 4.4.0 (5.0.0 available)
  platform 3.1.0
  plugin_platform_interface 2.1.2
  pool 1.5.0
> postgrest 0.1.10+1 (was 0.1.9)
  process 4.2.4
> pub_semver 2.1.1 (was 2.1.0)
  pubspec_parse 1.2.0
> realtime_client 0.1.15 (was 0.1.13)
  recase 4.0.0
> sentry 6.5.1 (was 6.2.2)
> sentry_dart_plugin 1.0.0-beta.2 (was 1.0.0-beta.1)
> sentry_flutter 6.5.1 (was 6.2.2)
> sentry_logging 6.5.1 (was 6.2.2)
  shelf 1.2.0 (1.3.0 available)
  shelf_packages_handler 3.0.0
  shelf_static 1.1.0
  shelf_web_socket 1.0.1
  sky_engine 0.0.99 from sdk flutter
> source_gen 1.2.2 (was 1.2.1)
> source_helper 1.3.2 (was 1.3.1)
  source_map_stack_trace 2.1.0
  source_maps 0.10.10
  source_span 1.8.1 (1.9.0 available)
  stack_trace 1.10.0
  storage_client 0.0.6+2
  stream_channel 2.1.0
  stream_transform 2.0.0
  string_scanner 1.1.0 (1.1.1 available)
> supabase 0.3.0 (was 0.2.10) (0.3.4 available)
> supabase_flutter 0.3.0 (was 0.2.9) (0.3.1 available)
> swagger_dart_code_generator 2.5.1+1 (was 2.3.4+1)
  sync_http 0.3.0
+ system_info2 2.0.3
  term_glyph 1.2.0
  test 1.19.5 (1.21.1 available)
  test_api 0.4.8 (0.4.9 available)
  test_core 0.4.9 (0.4.13 available)
  timing 1.0.0
  typed_data 1.3.0 (1.3.1 available)
  uni_links 0.5.1
  uni_links_platform_interface 1.0.0
  uni_links_web 0.1.0
  universal_io 2.0.4
> url_launcher 6.1.2 (was 6.0.18)
> url_launcher_android 6.0.17 (was 6.0.14)
> url_launcher_ios 6.0.16 (was 6.0.14)
> url_launcher_linux 3.0.1 (was 2.0.2)
> url_launcher_macos 3.0.1 (was 2.0.2)
  url_launcher_platform_interface 2.0.5
  url_launcher_web 2.0.6 (2.0.11 available)
> url_launcher_windows 3.0.1 (was 2.0.2)
> uuid 3.0.6 (was 3.0.5)
  vector_math 2.1.1 (2.1.2 available)
  vm_service 7.5.0 (8.3.0 available)
  watcher 1.0.1
> web_socket_channel 2.2.0 (was 2.1.0)
  webdriver 3.0.0
> webkit_inspection_protocol 1.0.1 (was 1.0.0)
> win32 2.5.2 (was 2.3.3)
> xdg_directories 0.2.0+1 (was 0.2.0)
  xml 5.3.1 (6.0.1 available)
> yaml 3.1.1 (was 3.1.0)
These packages are no longer being depended on:
- system_info 1.0.1
Downloading sentry_dart_plugin 1.0.0-beta.2...
Downloading msix 3.6.2...
Downloading swagger_dart_code_generator 2.5.1+1...
Downloading network_image_mock 2.1.0...
Downloading mockito 5.1.0...
Downloading flutter_contacts 1.1.4...
Downloading supabase_flutter 0.3.0...
Downloading package_info_plus 1.4.2...
Downloading loader_overlay 2.0.6...
Downloading json_annotation 4.5.0...
Downloading json_serializable 6.2.0...
Downloading geolocator 8.2.1...
Downloading flutter_facebook_auth 4.3.4...
Downloading system_info2 2.0.3...
Downloading get_it 7.2.0...
Downloading cli_dialog 0.5.0...
Downloading markdown 5.0.0...
Downloading supabase 0.3.0...
Downloading realtime_client 0.1.15...
Downloading package_info_plus_windows 1.0.5...
Downloading package_info_plus_web 1.0.5...
Downloading package_info_plus_linux 1.0.5...
Downloading flutter_facebook_auth_web 3.1.2...
Downloading flutter_facebook_auth_platform_interface 3.1.2...
Downloading hive 2.1.0...
Downloading yaml 3.1.1...
Downloading pub_semver 2.1.1...
Downloading args 2.3.1...
Downloading dart_console 1.0.0...
Downloading webkit_inspection_protocol 1.0.1...
Downloading web_socket_channel 2.2.0...
Downloading geolocator_windows 0.1.1...
Downloading build 2.3.0...
Downloading sentry_logging 6.5.1...
Downloading sentry_flutter 6.5.1...
Downloading http_multi_server 3.2.0...
Downloading mime 1.0.2...
Downloading postgrest 0.1.10+1...
Downloading gotrue 0.2.2...
Downloading source_helper 1.3.2...
Downloading geolocator_web 2.1.5...
Downloading geolocator_platform_interface 4.0.5...
Downloading geolocator_apple 2.1.3...
Downloading sentry 6.5.1...
Downloading image 3.1.3...
Downloading ffi 1.2.1...
Downloading uuid 3.0.6...
Downloading path_provider 2.0.10...
Downloading path_provider_windows 2.0.6...
Downloading path_provider_ios 2.0.9...
Downloading path_provider_platform_interface 2.0.4...
Downloading path_provider_macos 2.0.6...
Downloading path_provider_linux 2.1.6...
Downloading xdg_directories 0.2.0+1...
Downloading geolocator_android 3.1.8...
Downloading path_provider_android 2.0.14...
Downloading built_value 8.3.0...
Downloading fixnum 1.0.1...
Downloading source_gen 1.2.2...
Downloading url_launcher 6.1.2...
Downloading url_launcher_ios 6.0.16...
Downloading url_launcher_windows 3.0.1...
Downloading url_launcher_android 6.0.17...
Downloading url_launcher_macos 3.0.1...
Downloading url_launcher_linux 3.0.1...
Downloading win32 2.5.2...
Changed 70 dependencies!
34 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.

Changed 15 constraints in pubspec.yaml:
  flutter_facebook_auth: 4.0.0 -> ^4.3.4
  geolocator: 8.0.1 -> ^8.2.1
  json_serializable: 6.1.3 -> ^6.2.0
  json_annotation: 4.4.0 -> ^4.5.0
  loader_overlay: 2.0.5 -> ^2.0.6
  package_info_plus: 1.3.0 -> ^1.4.2
  sentry_flutter: 6.2.2 -> ^6.5.1
  supabase_flutter: 0.2.9 -> ^0.3.0
  flutter_contacts: 1.1.2 -> ^1.1.4
  sentry_logging: 6.2.2 -> ^6.5.1
  mockito: 5.0.17 -> ^5.1.0
  network_image_mock: 2.0.1 -> ^2.1.0
  swagger_dart_code_generator: 2.3.4+1 -> ^2.5.1+1
  msix: 2.8.1 -> ^3.6.2
  sentry_dart_plugin: 1.0.0-beta.1 -> ^1.0.0-beta.2
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- pubspec.lock
- pubspec.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)