### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.10"
+    version: "2.1.11"
   build_runner_core:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -141,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  cli_dialog:
+    dependency: transitive
+    description:
+      name: cli_dialog
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   cli_util:
     dependency: transitive
     description:
@@ -168,7 +175,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -182,7 +189,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -197,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  dart_console:
+    dependency: transitive
+    description:
+      name: dart_console
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -217,7 +231,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -290,7 +304,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -313,6 +327,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  functions_client:
+    dependency: transitive
+    description:
+      name: functions_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1-dev.4"
   geolocator:
     dependency: "direct main"
     description:
@@ -361,7 +382,14 @@ packages:
       name: get
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.1"
+    version: "4.6.3"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   glob:
     dependency: transitive
     description:
@@ -396,7 +424,7 @@ packages:
       name: gotrue
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.2"
   graphs:
     dependency: transitive
     description:
@@ -410,7 +438,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   hive_flutter:
     dependency: transitive
     description:
@@ -478,21 +506,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.5.0"
   json_serializable:
     dependency: "direct main"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.2.0"
   jwt_decode:
     dependency: "direct main"
     description:
@@ -534,14 +562,14 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   loader_overlay:
     dependency: "direct main"
     description:
       name: loader_overlay
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   logger:
     dependency: "direct main"
     description:
@@ -562,7 +590,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -576,7 +604,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   material_you_colours:
     dependency: "direct main"
     description:
@@ -606,14 +634,14 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.17"
+    version: "5.1.0"
   msix:
     dependency: "direct dev"
     description:
       name: msix
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "3.6.2"
   network_image_mock:
     dependency: "direct dev"
     description:
@@ -648,14 +676,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.2"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_info_plus_macos:
     dependency: transitive
     description:
@@ -676,21 +704,21 @@ packages:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -774,7 +802,7 @@ packages:
       name: postgrest
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.9"
+    version: "0.1.10+1"
   process:
     dependency: transitive
     description:
@@ -802,7 +830,7 @@ packages:
       name: realtime_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.13"
+    version: "0.1.15"
   recase:
     dependency: transitive
     description:
@@ -837,7 +865,7 @@ packages:
       name: sentry_logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.2"
+    version: "6.5.1"
   shelf:
     dependency: transitive
     description:
@@ -905,7 +933,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -947,21 +975,21 @@ packages:
       name: supabase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.10"
+    version: "0.3.4"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9"
+    version: "0.3.1"
   swagger_dart_code_generator:
     dependency: "direct dev"
     description:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.4+1"
+    version: "2.5.2"
   sync_http:
     dependency: transitive
     description:
@@ -989,21 +1017,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   timing:
     dependency: transitive
     description:
@@ -1115,14 +1143,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -1180,5 +1208,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,18 +39,18 @@ dependencies:
   logger: 1.1.0
   google_maps_webservice: 0.0.20-nullsafety.5
   geolocator: ^8.2.1
-  json_serializable: 6.1.3
-  json_annotation: 4.4.0
+  json_serializable: ^6.2.0
+  json_annotation: ^4.5.0
   android_metadata: 0.2.1
-  loader_overlay: 2.0.5
-  package_info_plus: 1.3.0
+  loader_overlay: ^2.0.6
+  package_info_plus: ^1.4.2
   sentry_flutter: ^6.5.1
-  get: 4.6.1
-  supabase_flutter: 0.2.9
+  get: ^4.6.3
+  supabase_flutter: ^0.3.1
   intl_phone_number_input: 0.7.0+2
   flutter_contacts: ^1.1.4
   jwt_decode: 0.3.1
-  sentry_logging: 6.2.2
+  sentry_logging: ^6.5.1
   material_you_colours:
     git:
       url: https://github.com/Mause/material_you_colours
@@ -69,14 +69,14 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: 1.0.4
+  flutter_lints: ^2.0.1
   test: ^1.19.5
   build_runner: 2.1.10
-  mockito: 5.0.17
+  mockito: ^5.1.0
   network_image_mock: ^2.1.0
   nock: 1.2.0
-  swagger_dart_code_generator: 2.3.4+1
-  msix: 2.8.1
+  swagger_dart_code_generator: ^2.5.2
+  msix: ^3.6.2
   golden_toolkit: 0.13.0
   sentry_dart_plugin: ^1.0.0-beta.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,7 +71,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.1
   test: ^1.19.5
-  build_runner: 2.1.10
+  build_runner: ^2.1.11
   mockito: ^5.1.0
   network_image_mock: ^2.1.0
   nock: 1.2.0


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/ChooseFood/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (39.0.0 available)
  analyzer 2.8.0 (4.0.0 available)
> archive 3.1.11 (was 3.1.6) (3.3.0 available)
  args 2.3.0 (2.3.1 available)
  async 2.8.2 (2.9.0 available)
  back_button_interceptor 5.0.2 (6.0.0 available)
  build 2.2.1 (2.3.0 available)
  build_resolvers 2.0.6 (2.0.8 available)
  built_value 8.1.3 (8.3.0 available)
  characters 1.2.0 (1.2.1 available)
+ cli_dialog 0.5.0
> collection 1.16.0 (was 1.15.0)
> coverage 1.2.0 (was 1.0.3) (1.3.1 available)
  crypto 3.0.1 (3.0.2 available)
+ dart_console 1.0.0
  dart_style 2.2.1 (2.2.3 available)
> fake_async 1.3.0 (was 1.2.0)
  ffi 1.1.2 (1.2.1 available)
  fixnum 1.0.0 (1.0.1 available)
  flutter_facebook_auth_platform_interface 3.1.2 (4.0.0 available)
  flutter_facebook_auth_web 3.1.2 (4.0.0 available)
> flutter_lints 2.0.1 (was 1.0.4)
+ functions_client 0.0.1-dev.4
> get 4.6.3 (was 4.6.1)
+ get_it 7.2.0
> gotrue 0.2.2 (was 0.1.2)
> hive 2.1.0 (was 2.0.5)
  http_multi_server 3.0.1 (3.2.0 available)
  image 3.1.0 (3.1.3 available)
> js 0.6.4 (was 0.6.3)
> json_annotation 4.5.0 (was 4.4.0)
> json_serializable 6.2.0 (was 6.1.3)
> lints 2.0.0 (was 1.0.1)
> loader_overlay 2.0.6 (was 2.0.5)
> markdown 5.0.0 (was 4.0.1)
> material_color_utilities 0.1.4 (was 0.1.3) (0.1.5 available)
  mime 1.0.1 (1.0.2 available)
> mockito 5.1.0 (was 5.0.17)
> msix 3.6.2 (was 2.8.1)
> package_info_plus 1.4.2 (was 1.3.0)
> package_info_plus_linux 1.0.5 (was 1.0.3)
> package_info_plus_web 1.0.5 (was 1.0.4)
> package_info_plus_windows 1.0.5 (was 1.0.4)
> path 1.8.1 (was 1.8.0)
  path_provider 2.0.8 (2.0.10 available)
  path_provider_android 2.0.11 (2.0.14 available)
  path_provider_ios 2.0.7 (2.0.9 available)
  path_provider_linux 2.1.5 (2.1.6 available)
  path_provider_macos 2.0.5 (2.0.6 available)
  path_provider_platform_interface 2.0.3 (2.0.4 available)
  path_provider_windows 2.0.5 (2.0.6 available)
  petitparser 4.4.0 (5.0.0 available)
> postgrest 0.1.10+1 (was 0.1.9)
  pub_semver 2.1.0 (2.1.1 available)
> realtime_client 0.1.15 (was 0.1.13)
> sentry_logging 6.5.1 (was 6.2.2)
  shelf 1.2.0 (1.3.0 available)
  source_gen 1.2.1 (1.2.2 available)
  source_helper 1.3.1 (1.3.2 available)
> source_span 1.8.2 (was 1.8.1) (1.9.0 available)
  string_scanner 1.1.0 (1.1.1 available)
> supabase 0.3.4 (was 0.2.10)
> supabase_flutter 0.3.1 (was 0.2.9)
> swagger_dart_code_generator 2.5.2 (was 2.3.4+1)
> test 1.20.2 (was 1.19.5) (1.21.1 available)
> test_api 0.4.9 (was 0.4.8)
> test_core 0.4.11 (was 0.4.9) (0.4.13 available)
  typed_data 1.3.0 (1.3.1 available)
  url_launcher 6.0.18 (6.1.2 available)
  url_launcher_android 6.0.14 (6.0.17 available)
  url_launcher_ios 6.0.14 (6.0.16 available)
  url_launcher_linux 2.0.2 (3.0.1 available)
  url_launcher_macos 2.0.2 (3.0.1 available)
  url_launcher_web 2.0.6 (2.0.11 available)
  url_launcher_windows 2.0.2 (3.0.1 available)
  uuid 3.0.5 (3.0.6 available)
> vector_math 2.1.2 (was 2.1.1)
> vm_service 8.2.2 (was 7.5.0) (8.3.0 available)
  web_socket_channel 2.1.0 (2.2.0 available)
  webkit_inspection_protocol 1.0.0 (1.0.1 available)
  win32 2.3.3 (2.6.1 available)
  xdg_directories 0.2.0 (0.2.0+1 available)
  xml 5.3.1 (6.0.1 available)
  yaml 3.1.0 (3.1.1 available)
Downloading supabase_flutter 0.3.1...
Downloading get 4.6.3...
Downloading package_info_plus 1.4.2...
Downloading loader_overlay 2.0.6...
Downloading json_annotation 4.5.0...
Downloading json_serializable 6.2.0...
Downloading msix 3.6.2...
Downloading swagger_dart_code_generator 2.5.2...
Downloading mockito 5.1.0...
Downloading supabase 0.3.4...
Downloading package_info_plus_windows 1.0.5...
Downloading package_info_plus_web 1.0.5...
Downloading package_info_plus_linux 1.0.5...
Downloading get_it 7.2.0...
Downloading cli_dialog 0.5.0...
Downloading markdown 5.0.0...
Downloading realtime_client 0.1.15...
Downloading postgrest 0.1.10+1...
Downloading gotrue 0.2.2...
Downloading functions_client 0.0.1-dev.4...
Downloading hive 2.1.0...
Downloading dart_console 1.0.0...
Downloading sentry_logging 6.5.1...
Changed 38 dependencies!

Changed 11 constraints in pubspec.yaml:
  json_serializable: 6.1.3 -> ^6.2.0
  json_annotation: 4.4.0 -> ^4.5.0
  loader_overlay: 2.0.5 -> ^2.0.6
  package_info_plus: 1.3.0 -> ^1.4.2
  get: 4.6.1 -> ^4.6.3
  supabase_flutter: 0.2.9 -> ^0.3.1
  sentry_logging: 6.2.2 -> ^6.5.1
  flutter_lints: 1.0.4 -> ^2.0.1
  mockito: 5.0.17 -> ^5.1.0
  swagger_dart_code_generator: 2.3.4+1 -> ^2.5.2
  msix: 2.8.1 -> ^3.6.2
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- pubspec.lock
- pubspec.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)