### PR TITLE
chore: update flutter dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   back_button_interceptor:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -231,7 +231,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -304,7 +304,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -506,7 +506,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
@@ -562,7 +562,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   loader_overlay:
     dependency: "direct main"
     description:
@@ -604,7 +604,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   material_you_colours:
     dependency: "direct main"
     description:
@@ -655,7 +655,7 @@ packages:
       name: nock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   node_preamble:
     dependency: transitive
     description:
@@ -718,7 +718,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -933,7 +933,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -1017,21 +1017,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   timing:
     dependency: transitive
     description:
@@ -1143,14 +1143,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -1208,5 +1208,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.2 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,12 +70,12 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: 1.0.4
+  flutter_lints: ^2.0.1
   test: ^1.19.5
   build_runner: ^2.1.11
   mockito: ^5.2.0
   network_image_mock: ^2.1.0
-  nock: 1.1.3
+  nock: ^1.2.0
   swagger_dart_code_generator: ^2.6.0
   msix: ^3.6.2
   golden_toolkit: 0.13.0


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/ChooseFood/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>flutter pub upgrade --major-versions</em></summary>

```Shell
Resolving dependencies...
  _fe_analyzer_shared 31.0.0 (40.0.0 available)
  analyzer 2.8.0 (4.1.0 available)
> archive 3.1.11 (was 3.1.6) (3.3.0 available)
  args 2.3.0 (2.3.1 available)
> async 2.9.0 (was 2.8.2)
  build 2.2.1 (2.3.0 available)
  build_resolvers 2.0.6 (2.0.9 available)
  built_value 8.1.3 (8.3.2 available)
  characters 1.2.0 (1.2.1 available)
> collection 1.16.0 (was 1.15.0)
  convert 3.0.1 (3.0.2 available)
> coverage 1.2.0 (was 1.0.3) (1.3.2 available)
  crypto 3.0.1 (3.0.2 available)
  dart_style 2.2.1 (2.2.3 available)
> fake_async 1.3.0 (was 1.2.0)
  ffi 1.1.2 (2.0.0 available)
  fixnum 1.0.0 (1.0.1 available)
  flutter_facebook_auth 4.3.4 (4.3.4+2 available)
  flutter_facebook_auth_platform_interface 3.1.2 (4.0.0 available)
  flutter_facebook_auth_web 3.1.2 (4.0.0 available)
> flutter_lints 2.0.1 (was 1.0.4)
  frontend_server_client 2.1.2 (2.1.3 available)
  geolocator_android 3.1.8 (3.2.0 available)
  geolocator_apple 2.1.3 (2.2.0 available)
  hive 2.2.1 (2.2.2 available)
  http_multi_server 3.0.1 (3.2.0 available)
  http_parser 4.0.0 (4.0.1 available)
  image 3.1.0 (3.2.0 available)
> js 0.6.4 (was 0.6.3)
> lints 2.0.0 (was 1.0.1)
> material_color_utilities 0.1.4 (was 0.1.3) (0.1.5 available)
  meta 1.7.0 (1.8.0 available)
  mime 1.0.1 (1.0.2 available)
> nock 1.2.0 (was 1.1.3)
> path 1.8.1 (was 1.8.0) (1.8.2 available)
  path_provider 2.0.8 (2.0.11 available)
  path_provider_android 2.0.11 (2.0.14 available)
  path_provider_ios 2.0.7 (2.0.9 available)
  path_provider_linux 2.1.5 (2.1.7 available)
  path_provider_macos 2.0.5 (2.0.6 available)
  path_provider_platform_interface 2.0.3 (2.0.4 available)
  path_provider_windows 2.0.5 (2.1.0 available)
  petitparser 4.4.0 (5.0.0 available)
  pub_semver 2.1.0 (2.1.1 available)
  shelf 1.2.0 (1.3.0 available)
  source_gen 1.2.1 (1.2.2 available)
  source_helper 1.3.1 (1.3.2 available)
> source_span 1.8.2 (was 1.8.1) (1.9.0 available)
  string_scanner 1.1.0 (1.1.1 available)
  supabase 0.3.4 (0.3.4+1 available)
  supabase_flutter 0.3.1+1 (0.3.1+2 available)
  system_info2 2.0.3 (2.0.4 available)
> test 1.20.2 (was 1.19.5) (1.21.1 available)
> test_api 0.4.9 (was 0.4.8)
> test_core 0.4.11 (was 0.4.9) (0.4.13 available)
  typed_data 1.3.0 (1.3.1 available)
  url_launcher 6.1.2 (6.1.3 available)
  url_launcher_android 6.0.14 (6.0.17 available)
  url_launcher_ios 6.0.14 (6.0.17 available)
  url_launcher_linux 2.0.2 (3.0.1 available)
  url_launcher_macos 2.0.2 (3.0.1 available)
  url_launcher_web 2.0.6 (2.0.11 available)
  url_launcher_windows 2.0.2 (3.0.1 available)
  uuid 3.0.5 (3.0.6 available)
> vector_math 2.1.2 (was 2.1.1)
> vm_service 8.2.2 (was 7.5.0) (8.3.0 available)
  web_socket_channel 2.1.0 (2.2.0 available)
  webkit_inspection_protocol 1.0.0 (1.1.0 available)
  win32 2.5.2 (2.7.0 available)
  xdg_directories 0.2.0 (0.2.0+1 available)
  xml 5.3.1 (6.1.0 available)
  yaml 3.1.0 (3.1.1 available)
Downloading nock 1.2.0...
Changed 17 dependencies!

Changed 2 constraints in pubspec.yaml:
  flutter_lints: 1.0.4 -> ^2.0.1
  nock: 1.1.3 -> ^1.2.0
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- pubspec.lock
- pubspec.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)